### PR TITLE
fix: add exposed default TCP port, change the image to management-tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ mongo:
   ports:
     - "27017:27017"
 rabbitmq:
-  image: rabbitmq:latest
+  image: rabbitmq:3-management
   ports:
+    - "5672:5672"
     - "15672:15672"


### PR DESCRIPTION
fix: add exposed default TCP port, change the image to management-tag
- add missing default exposed TCP AQMP port 5672 to allow connections
- change the image tag to rabbitmq:[3-management](https://hub.docker.com/_/rabbitmq/
  in order to be able to use the plugin with the already exposed 15672 port

close #1
